### PR TITLE
Precise input type=range check

### DIFF
--- a/js/fd-slider.js
+++ b/js/fd-slider.js
@@ -183,7 +183,7 @@ var fdSlider = (function() {
         for(var i = 0, inp; inp = inputs[i]; i++) {
 
             if(inp.tagName.toLowerCase() == "input" &&
-               inp.type.toLowerCase() == "text" &&
+               inp.getAttribute("type").toLowerCase() == "range" &&
                (getAttribute(inp, "min") && getAttribute(inp, "min").search(fpRegExp) != -1 ||
                 getAttribute(inp, "max") && getAttribute(inp, "max").search(fpRegExp) != -1 ||
                 getAttribute(inp, "step") && getAttribute(inp, "step").search(/^(any|([0-9]+(\.[0-9]+){0,1}))$/i) != -1


### PR DESCRIPTION
This avoids clobbering `<input type="number">` controls which also have min/max/step attributes.

Tested as far back as IE8
